### PR TITLE
Added updated CookieYes banner to <head>

### DIFF
--- a/src/layouts/partials/head.html
+++ b/src/layouts/partials/head.html
@@ -52,6 +52,8 @@
     <meta property="og:image:alt" content="sh &lt;(curl tea.xyz)" />
     <meta name="facebook-domain-verification" content="0fsbdl7joh0gha23zbhtovtpn0z0cl" />
 
+    <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/e64508136bc06d018940f2f3/script.js"></script>
+
     <script>
       const q = window.location.search.match(/[\^\?&]store=[^&]*/)
       if (q) {


### PR DESCRIPTION
This makes the site GDPR compliant. The banner is geo-targeted to only show for EU and UK users. The banner has been made 40% smaller, as per mxcl's comment. @Xercesblu3 you will need to use a VPN to test accordingly. 

Note: PR #54 must be merged first, as this banner connects to the Privacy Policy page. 