### PR TITLE
Change CTA to say 'Authenticate with GitHub'... new LP's only

### DIFF
--- a/src/layouts/page/keep-what-is-yours.html
+++ b/src/layouts/page/keep-what-is-yours.html
@@ -3,6 +3,11 @@
 
 <!-- Styling for this landing page only -->
 
+
+  <script>
+    document.getElementById("nav-cta").innerHTML = "Authenticate with GitHub";
+  </script>
+
   <style>
 
     .badge{

--- a/src/layouts/page/pioneer-a-better-internet.html
+++ b/src/layouts/page/pioneer-a-better-internet.html
@@ -1,6 +1,10 @@
 {{ define "main" }}
   <!-- Hero Section -->
 
+  <script>
+    document.getElementById("nav-cta").innerHTML = "Authenticate with GitHub";
+  </script>
+
   <style>
 
     .badge{

--- a/src/layouts/partials/navbar.html
+++ b/src/layouts/partials/navbar.html
@@ -22,7 +22,7 @@
           </li>
           {{ end }}
         </ul>
-        <a class="btn btn-primary auth-btn mt-lg-0 mt-md-0 mt-sm-4 mt-4" href="https://github.com/login/oauth/authorize?client_id=9d1f1a72f1300b6991df&state=teaxyz" role="button">Authenticate with tea<span class="badge rounded-pill bg-primary ms-3"><span id="count1">287</span></span></a>
+        <a class="btn btn-primary auth-btn mt-lg-0 mt-md-0 mt-sm-4 mt-4" id="nav-cta" href="https://github.com/login/oauth/authorize?client_id=9d1f1a72f1300b6991df&state=teaxyz" role="button">Authenticate with tea<span class="badge rounded-pill bg-primary ms-3"><span id="count1">287</span></span></a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
Change navbar CTA to say "Authenticate with GitHub" on new landing pages only ( /pioneer-a-better-internet/ & /keep-what-is-yours/ ).  