### PR TITLE
Added necessary ID's to navbar CTA to edit with JS on landing page.

### DIFF
--- a/src/layouts/page/keep-what-is-yours.html
+++ b/src/layouts/page/keep-what-is-yours.html
@@ -4,14 +4,22 @@
 <!-- Styling for this landing page only -->
 
 
-  <script>
-    document.getElementById("nav-cta").innerHTML = "Authenticate with GitHub";
+<script>
+    document.getElementById("lp-text").innerHTML = "Developers Authenticated";
   </script>
 
   <style>
 
-    .badge{
+    #cta-text{
       display:none;
+    }
+
+    #lp-text{
+      margin-left: 10px;
+    }
+
+    .ms-3{
+      margin:0px !important;
     }
 
     @media only screen and (min-width: 600px) {

--- a/src/layouts/partials/navbar.html
+++ b/src/layouts/partials/navbar.html
@@ -22,7 +22,7 @@
           </li>
           {{ end }}
         </ul>
-        <a class="btn btn-primary auth-btn mt-lg-0 mt-md-0 mt-sm-4 mt-4" id="nav-cta" href="https://github.com/login/oauth/authorize?client_id=9d1f1a72f1300b6991df&state=teaxyz" role="button">Authenticate with tea<span class="badge rounded-pill bg-primary ms-3"><span id="count1">287</span></span></a>
+        <a class="btn btn-primary auth-btn mt-lg-0 mt-md-0 mt-sm-4 mt-4" id="nav-cta" href="https://github.com/login/oauth/authorize?client_id=9d1f1a72f1300b6991df&state=teaxyz" role="button"><span id="cta-text">Authenticate with tea</span><span class="badge rounded-pill bg-primary ms-3"><span id="count1">287</span></span><span id="lp-text"></span></a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
Request from Gypsy for top menu CTA to say "(no. of devs) Developers Authenticated" only on one of the landing pages. 

From Gypsy:

"We would however like to adjust the wording slightly so it is more descriptive. Instead of "Authenticate with tea (4729)" (from the homepage) / "Authenticate with Github" (from the LP tests) can we switch this feature around to read "(4729) Developers Authenticated"? i.e. adding more clarity around the meaning of the # and swapping the position of the number with the copy. For the two lower CTAs, we think keeping "Authenticate with Github" can remain as-is as the action verb is more likely to incite a click."

This can be viewed on /keep-what-is-yours/