### PR TITLE
Revert email auth flow

### DIFF
--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -12,7 +12,7 @@
             decades, big tech has made trillions off the generosity of visionary developers and web pioneers… never
             thanking, never mentioning, and certainly never paying. At tea, we’re brewing something to change that by
             enabling developers (you) to continue doing what you love, while earning what you deserve.</p>
-          <a class="btn btn-primary auth-btn mb-3" href="/email-subscribe/"
+          <a class="btn btn-primary auth-btn mb-3" href="https://github.com/login/oauth/authorize?client_id=9d1f1a72f1300b6991df&state=teaxyz"
             role="button">Authenticate with tea<span class="badge rounded-pill bg-primary ms-3"><span
                 id="count2">287</span></span></a><br>
           <a class="btn btn-primary mb-sm-5 mb-md-5 mb-5" id="whitepaper-btn" href="/white-paper/"

--- a/src/layouts/page/authentication-success.html
+++ b/src/layouts/page/authentication-success.html
@@ -13,8 +13,11 @@
             transform: translate(-50%, -50%);">
         <h1 class="display-4 text-center">Thanks for Authenticating!</h1>
         <p class="lead text-center mb-5">You've just become an integral part in the future of the internet, AND you'll be entitled to a variety of exciting rewards such as minted NFT badges to honor your work thus far.</p>
-        <a class="btn btn-primary mb-3" href="https://tea.xyz"
+        <a class="btn btn-primary mb-5" href="https://tea.xyz"
           role="button">Return to Home</a>
+        <hr>
+        <h3 class="text-center mb-4 display-6">Stay up to date on all the latest tea news</h3>
+        {{- partial "klaviyo-form.html" -}}
       </div>
     </div>
   </div>

--- a/src/layouts/page/authentication-success.html
+++ b/src/layouts/page/authentication-success.html
@@ -15,9 +15,6 @@
         <p class="lead text-center mb-5">You've just become an integral part in the future of the internet, AND you'll be entitled to a variety of exciting rewards such as minted NFT badges to honor your work thus far.</p>
         <a class="btn btn-primary mb-5" href="https://tea.xyz"
           role="button">Return to Home</a>
-        <hr>
-        <h3 class="text-center mb-4 display-6">Stay up to date on all the latest tea news</h3>
-        {{- partial "klaviyo-form.html" -}}
       </div>
     </div>
   </div>

--- a/src/layouts/page/keep-what-is-yours.html
+++ b/src/layouts/page/keep-what-is-yours.html
@@ -85,7 +85,7 @@
   <div class="container pt-5 pb-5">
     <div class="row">
       <div class="col" style="z-index:100;">
-        <h1 class="prompt yellow">KEEP <br>WHAT IS <br>YOURS.<a class="btn btn-primary auth-btn mb-3 mt-5 ms-lg-5 ms-md-0 ms-sm-0 ms-0" id="keep-btn-top" style="font-family:var(--bs-body-font-family)!important; vertical-align:bottom;" href="/email-subscribe/" role="button">Authenticate with GitHub</a></h1>
+        <h1 class="prompt yellow">KEEP <br>WHAT IS <br>YOURS.<a class="btn btn-primary auth-btn mb-3 mt-5 ms-lg-5 ms-md-0 ms-sm-0 ms-0" id="keep-btn-top" style="font-family:var(--bs-body-font-family)!important; vertical-align:bottom;" href="https://github.com/login/oauth/authorize?client_id=9d1f1a72f1300b6991df&state=teaxyz" role="button">Authenticate with GitHub</a></h1>
         <p style="color:#b3c8c8;" class="mt-5 mb-5 lead">Equitable Open-Source for web3</p>
       </div>
     </div>
@@ -94,7 +94,7 @@
         <h2 class="display-3">Over 10 thousand developers have authenticated their Github with tea. This is your chance to be an early member of our Communitea.</h2>
         <div class="row">
           <div class="col-lg-6 p-0">
-            <a style="border: 2px solid #54BAAB;" class="btn btn-primary auth-btn mb-3 mt-4" id="keep-btn-bottom" href="/email-subscribe/" role="button">Authenticate with GitHub</a>
+            <a style="border: 2px solid #54BAAB;" class="btn btn-primary auth-btn mb-3 mt-4" id="keep-btn-bottom" href="https://github.com/login/oauth/authorize?client_id=9d1f1a72f1300b6991df&state=teaxyz" role="button">Authenticate with GitHub</a>
             <a class="btn btn-primary mt-lg-4 mt-md-4 mt-sm-0 mt-0 whitepaper-btn-right" id="whitepaper-btn" href="/white-paper/"
               role="button" style="background:transparent; float:right;">Read Our White Paper</a>
           </div>

--- a/src/layouts/page/pioneer-a-better-internet.html
+++ b/src/layouts/page/pioneer-a-better-internet.html
@@ -108,7 +108,7 @@
           <p class="syne-body text-center mb-5 mt-5"><span class="yellow">tea</span> is putting an end to Big Tech making trillions off the generosity
             of the visionary developers and web pioneers who built the internet.
             You can be a part of this revolution.<br><br><span style="font-weight:700;">Authenticate now to gain early access to the <span class="teal">tea beta</span>.</span></p>
-          <a class="btn btn-primary auth-btn syne-btn mt-5 mb-3" href="/email-subscribe/"
+          <a class="btn btn-primary auth-btn syne-btn mt-5 mb-3" href="https://github.com/login/oauth/authorize?client_id=9d1f1a72f1300b6991df&state=teaxyz"
             role="button">Authenticate with GitHub</a>
           <p class="small text-center syne-boiler">Limited numbers of tea beta invites will be given to the first devs who authenticate
 their Github account. So don’t delay, get it while it’s hot.</p>

--- a/src/layouts/partials/navbar.html
+++ b/src/layouts/partials/navbar.html
@@ -22,7 +22,7 @@
           </li>
           {{ end }}
         </ul>
-        <a class="btn btn-primary auth-btn mt-lg-0 mt-md-0 mt-sm-4 mt-4" id="nav-cta" href="/email-subscribe/" role="button"><span id="cta-text">Authenticate with tea</span><span class="badge rounded-pill bg-primary ms-3"><span id="count1">287</span></span><span id="lp-text"></span></a>
+        <a class="btn btn-primary auth-btn mt-lg-0 mt-md-0 mt-sm-4 mt-4" id="nav-cta" href="https://github.com/login/oauth/authorize?client_id=9d1f1a72f1300b6991df&state=teaxyz" role="button"><span id="cta-text">Authenticate with tea</span><span class="badge rounded-pill bg-primary ms-3"><span id="count1">287</span></span><span id="lp-text"></span></a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
@Xercesblu3 removed the email page and re-directed the CTA's to click-through to GitHub (as they were before). There's no check box on the /authentication-success/ page yet--as I'm not certain we have a way to tie those 'form submissions' to the corresponding email associated with their 'authed' GitHub account. It may be worth merging these changes to clear the way for more auths this weekend, and then continue to figure GitHub emails/check box consent after. 