### PR TITLE
'open in terminal' button added

### DIFF
--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -22,7 +22,7 @@
   </div>
 </section>
   <div class="full-width-cta-container">
-   {{- partial "clipboard-copy.html" . -}}
+   {{- partial "open-in-terminal.html" . -}}
   </div>
   <div class="hero-bottom">
 

--- a/src/layouts/partials/open-in-terminal.html
+++ b/src/layouts/partials/open-in-terminal.html
@@ -1,0 +1,319 @@
+<hr>
+  <div class="row gx-0 click-copy-container" onclick="myFunction()" style="display:flex; justify-content:space-between;">
+    <input class="one-liner" type="text" value="sh <(curl tea.xyz)" id="shortcodeCopy" readonly>
+
+    <!-- The button used to copy the text -->
+    <div class="buttons">
+      <hr class="mobile-btn-divider">
+      <button type="button" class="clipboard-copy" id="open-terminal">open in terminal</button>
+      <button type="button" class="clipboard-copy" id="liveToastBtn" onclick="changeCopied()">copy</button>
+    </div>
+  </div>
+<hr>
+
+<style>
+
+  @media only screen and (min-width: 1200px) {
+
+    .click-copy-container{
+      padding: 0vw 8.371vw;
+    }
+
+    .one-liner{
+      width: 40%;
+      padding: 2.455vw 4.185vw;
+      border-radius: 0px;
+      border: none;
+      background-color: #1a1a1a !important;
+      font-family: "pp-neue-machina";
+      color:#ffffff;
+      font-size: 2vw;
+      border-left: 2px solid #949494;
+    }
+
+    .one-liner:focus{
+      border:none;
+      outline: none;
+      border-left: 2px solid #949494;
+    }
+
+    .clipboard-copy{
+      height: 8.371vw;
+      font-family: "pp-neue-machina";
+      color:#ffffff;
+      font-size: 2.1vw;
+      float:right !important;
+      background-color: #1a1a1a !important;
+      border: none;
+      border-right: 2px solid #949494;
+      transition: 0.2s linear;
+      padding: 0px 30px;
+    }
+
+    .clipboard-copy:hover{
+      background-color: #00ffd0 !important;
+      color: #1a1a1a !important;
+      box-shadow: inset 0vw 0vw 0vw 0.558vw #1a1a1a !important;
+    }
+
+    .buttons{
+      width: 60%;
+    }
+
+    #liveToastBtn{
+      border-left: 2px solid #949494;
+    }
+
+    .mobile-btn-divider{
+      display: none;
+    }
+
+  }
+
+  @media only screen and (min-width: 992px) and (max-width: 1200px) {
+
+    .click-copy-container{
+      padding: 0vw 10vw;
+    }
+
+    .one-liner{
+      width: 40%;
+      padding: 2.455vw 4.185vw;
+      border-radius: 0px;
+      border: none;
+      background-color: #1a1a1a !important;
+      font-family: "pp-neue-machina";
+      color:#ffffff;
+      font-size: 2vw;
+      border-left: 2px solid #949494;
+    }
+
+    .one-liner:focus{
+      border:none;
+      outline: none;
+      border-left: 2px solid #949494;
+    }
+
+    .clipboard-copy{
+      height: 8.371vw;
+      font-family: "pp-neue-machina";
+      color:#ffffff;
+      font-size: 2.1vw;
+      float:right !important;
+      background-color: #1a1a1a !important;
+      border: none;
+      border-right: 2px solid #949494;
+      transition: 0.2s linear;
+      padding: 0px 30px;
+    }
+
+    .clipboard-copy:hover{
+      background-color: #00ffd0 !important;
+      color: #1a1a1a !important;
+      box-shadow: inset 0vw 0vw 0vw 0.558vw #1a1a1a !important;
+    }
+
+    .buttons{
+      width: 60%;
+    }
+
+    #liveToastBtn{
+      border-left: 2px solid #949494;
+    }
+
+    .mobile-btn-divider{
+      display: none;
+    }
+
+  }
+
+  @media only screen and (min-width: 768px) and (max-width: 992px) {
+
+    .click-copy-container{
+      padding: 0vw 5.040vw;
+    }
+
+    .one-liner{
+      width: 40%;
+      padding: 2.455vw 5.040vw !important;
+      border-radius: 0px;
+      border: none;
+      background-color: #1a1a1a !important;
+      font-family: "pp-neue-machina";
+      color:#ffffff;
+      font-size: 2vw;
+      border-left: 2px solid #949494;
+    }
+
+    .one-liner:focus{
+      border:none;
+      outline: none;
+      border-left: 2px solid #949494;
+    }
+
+    .clipboard-copy{
+      height: 8.371vw;
+      font-family: "pp-neue-machina";
+      color:#ffffff;
+      font-size: 2.1vw;
+      float:right !important;
+      background-color: #1a1a1a !important;
+      border: none;
+      border-right: 2px solid #949494;
+      transition: 0.2s linear;
+      padding: 0px 30px;
+    }
+
+    .clipboard-copy:hover{
+      background-color: #00ffd0 !important;
+      color: #1a1a1a !important;
+      box-shadow: inset 0vw 0vw 0vw 0.558vw #1a1a1a !important;
+    }
+
+    .buttons{
+      width: 60%;
+    }
+
+    #liveToastBtn{
+      border-left: 2px solid #949494;
+    }
+
+    .mobile-btn-divider{
+      display: none;
+    }
+
+  }
+
+  @media only screen and (min-width: 576px) and (max-width: 768px) {
+
+    .click-copy-container{
+      padding: 0vw 6.510vw;
+    }
+
+    .one-liner{
+      width: 100%;
+      padding: 5vw 4vw;
+      border-radius: 0px;
+      text-align: center;
+      border: none;
+      border-right: 2px solid #949494;
+      background-color: #1a1a1a !important;
+      font-family: "pp-neue-machina";
+      color:#ffffff;
+      font-size: 3.5vw;
+      border-left: 2px solid #949494;
+      boder-bottom: 2px solid #949494 !important;
+    }
+
+    .one-liner:focus{
+      border:none;
+      outline: none;
+      border-left: 2px solid #949494;
+    }
+
+    .clipboard-copy{
+      padding: 5vw 4vw;
+      width:50%;
+      font-family: "pp-neue-machina";
+      color:#ffffff;
+      font-size: 3.5vw;
+      float:right;
+      background-color: #1a1a1a !important;
+      border: none;
+      border-right: 2px solid #949494;
+      transition: 0.2s linear;
+    }
+
+    .clipboard-copy:hover{
+      background-color: #00ffd0 !important;
+      color: #1a1a1a !important;
+      box-shadow: inset 0vw 0vw 0vw 1vw #1a1a1a !important;
+    }
+
+    .buttons{
+      width: 100%;
+    }
+
+    #liveToastBtn{
+      border-left: 2px solid #949494;
+    }
+
+  }
+
+  @media only screen and (max-width: 576px) {
+
+    .click-copy-container{
+      padding: 0vw 6.076vw;
+    }
+
+    .one-liner{
+      width: 100%;
+      padding: 7.5vw 7.5vw !important;
+      border-radius: 0px;
+      border: none;
+      background-color: #1a1a1a !important;
+      font-family: "pp-neue-machina";
+      color:#ffffff;
+      text-align: center !important;
+      font-size: 4vw;
+      border-left: 2px solid #949494;
+      border-right: 2px solid #949494;
+    }
+
+    .one-liner:focus{
+      border:none;
+      outline: none;
+      border-left: 2px solid #949494;
+      border-right: 2px solid #949494;
+    }
+
+    .clipboard-copy{
+      padding: 5vw 4vw;
+      width:50%;
+      font-family: "pp-neue-machina";
+      color:#ffffff;
+      font-size: 3.5vw;
+      float:right;
+      background-color: #1a1a1a !important;
+      border: none;
+      border-right: 2px solid #949494;
+      transition: 0.2s linear;
+    }
+
+    .clipboard-copy:hover{
+      background-color: #00ffd0 !important;
+      color: #1a1a1a !important;
+      box-shadow: inset 0vw 0vw 0vw 1vw #1a1a1a !important;
+    }
+
+    .buttons{
+      width: 100%;
+    }
+
+    #liveToastBtn{
+      border-left: 2px solid #949494;
+    }
+
+  }
+
+</style>
+
+<script>
+
+    function changeCopied() {
+    // Get the text field
+    var copyText = document.getElementById("shortcodeCopy");
+
+    // Select the text field
+    copyText.select();
+    copyText.setSelectionRange(0, 99999); // For mobile devices
+
+     // Copy the text inside the text field
+    navigator.clipboard.writeText(copyText.value);
+
+
+    document.getElementById("liveToastBtn").innerHTML = "copied!";
+
+  }
+
+</script>


### PR DESCRIPTION
Added a button to the click-to-copy CTA bar that says 'Open in Terminal'. This PR is associated with the [work being done here](https://github.com/teaxyz/cli/issues/97), and _thus should not be merged_ until that ticket has been closed. CTA bar has been made so that the buttons fall to second line on tablet and mobile. 

Link to Loom video: 

https://www.loom.com/share/c0b7616789c14a8585f064d9324170b5