### PR TITLE
space missing on package detail page

### DIFF
--- a/src/layouts/page/package-detail.html
+++ b/src/layouts/page/package-detail.html
@@ -36,7 +36,7 @@
   <div class="container">
     <div class="row">
       <div class="col grid-gray">
-        Copy the tea one-liner below into your terminal to install {{- .Title -}}. tea will interpret the documentation and take care of any dependencies.
+        Copy the tea one-liner below into your terminal to install &#160;{{- .Title -}}. tea will interpret the documentation and take care of any dependencies.
       </div>
     </div>
   </div>


### PR DESCRIPTION
The space was missing on the live site, so this is the attempted fix for said issue. This closes [https://github.com/teaxyz/www/issues/219](https://github.com/teaxyz/www/issues/219).