### PR TITLE
Statistic Subtitle Fix

### DIFF
--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -211,7 +211,7 @@
         <div class="metric-block" style="float:right; margin-top:-300px;">
           <p class="stat-head">NUMBER OF REPOS</p>
           <p class="stat-number teal" id="stat-one"></p>
-          <p class="small gray stat-small-text">Number of rated repos owned by tea&#8208;authenticated developers.</p>
+          <p class="gray stat-small-text">Number of rated repos owned by tea&#8208;authenticated developers.</p>
         </div>
         <div class="gen-art-mobile" id="m-gen-art-3"></div>
         <div class="gen-art-mobile" id="m-gen-art-4"></div>
@@ -219,7 +219,7 @@
         <div class="metric-block mb-5 mt-4">
           <p class="stat-head">AUTHENTICATED DEVS</p>
           <p class="stat-number teal"><span id="count2"></span></p>
-          <p class="small gray stat-small-text">This is the number of OSS developers who have chosen to join the battle for the future of the internet.</p>
+          <p class="gray stat-small-text">This is the number of OSS developers who have chosen to join the battle for the future of the internet.</p>
         </div>
         <div class="gen-art-mobile" id="m-gen-art-5"></div>
         <div class="gen-art-mobile" id="m-gen-art-6"></div>
@@ -227,7 +227,7 @@
         <div class="metric-block" style="float:right;">
           <p class="stat-head">TEA MAINTAINERS</p>
           <p class="stat-number teal" id="stat-two"></p>
-          <p class="small gray stat-small-text">Number of tea-maintainers for those 2042 packages.</p>
+          <p class="gray stat-small-text">Number of tea-maintainers for those <span id="stat-one-small"></span> repos.</p>
         </div>
         <div class="gen-art-mobile" id="m-gen-art-7"></div>
         <div class="gen-art-mobile" id="m-gen-art-8"></div>

--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -90,6 +90,7 @@ integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+
         $('#count6').html(signups)
         $('#count7').html(signups)
         $('#stat-one').html(res.repos ? res.repos.toLocaleString() : "")
+        $('#stat-one-small').html(res.repos ? res.repos.toLocaleString() : "")
         $('#stat-two').html(res.maintainers ? res.maintainers.toLocaleString() : "")
       })
   } catch (e) {


### PR DESCRIPTION
There was a number in the stat sub-text that was still static. This amends that. I also made the sub-text slightly larger as it seemed to be a little on the tiny side. 

<img width="650" alt="Screen Shot 2022-12-15 at 7 57 29 PM" src="https://user-images.githubusercontent.com/49042513/207998215-614f2726-8d23-474a-94a3-9bd2f168f987.png">
