### PR TITLE
Remove web3 & Crypto Verbiage

### DIFF
--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -198,8 +198,8 @@
     <div class="row mb-5">
       <div class="col-xl-6 col-lg-6 col-md-6 col-sm-12">
         <h2>sta'tea'stics</h2>
-        <p class="lead">The problem is bigger than most realize. While everyday people use software every day, very few understand that the technology underlying their daily routine is provided by uncompensated labor.</p>
-        <p>Even many developers don’t fully recognize the security risks of unpaid open-source until something deep in the stack collapses, like log4J.We want to shine a light on the scale of OSS usage, both to celebrate the achievements of unsung heroes as well as highlight the need for a better way.</p><br>
+        <p class="lead">Much like its predecessor, <a href="https://brew.sh/">brew</a>, tea is seeing a rapid rate of adoption. Developers around the world are doing amazing things with our next&#8208;generation, cross&#8208;platform package manager.</p>
+        <p>In true open&#8208;source fashion, we&#39;re asking the community for <a href="https://github.com/teaxyz/cli">contributions to tea/cli</a>, as well as packaging assistance in an effort to add the web&#39;s top 300 packages to <a href="https://github.com/teaxyz/pantry.zero#contributing">our pantry</a>. Now is the time to be an early contributor in what will inevitably become the foundation of the future internet.</p><br>
         <!-- Commenting this out until more data is available. Everything can fit on the homepage as of now.
         {{- partial "detail-btn-large.html" "#" -}}
         -->

--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -64,10 +64,8 @@
   <div class="container package_before">
     <div class="row one-box">
       <div class="col-xl-6 col-lg-6 col-md-6 col-sm-12 col-12">
-        <h2 style="margin-bottom: 1vw;">about tea.</h2>
-        <p class="lead">tea.xyz is a feature-rich, delightful unified package manager that will revolutionize open-source development by providing creators and maintainers value for previously unpaid labor.</p>
-        <p>We’ve reimagined what a package manager can do for the first time since brew with new features such as executable markdown, a virtual environment manager, and universal interpretation. In short, we’ve built a tool that improves how you develop by getting out of your way so you can keep building.</p>
-        <p>Next we’re going to change the way you get rewarded for what you build by implementing a blockchain protocol that finally recognizes your hard work in open-source. You won’t have to use our web3 features to use tea, but we think you’ll want to. <a class="teal" href="/white-paper/">Check out our whitepaper for more details.</a></p>
+        <h2 style="margin-bottom: 1vw;">The unified packaging infrastructure.</h2>
+        <p class="lead">Access the latest tools, languages and frameworks seamlessly across all platforms with tea&#8212;the standalone, binary download from the creator of brew. Unleash the power of the open-source ecosystem by <a href="https://github.com/teaxyz/setup/blob/main/install.sh">installing tea</a> today.</p>
         <img class="mobile-grid-element" src="/Images/mobile-grid-element-3-rows.svg" alt="grid">
         <div class="gen-art-mobile" id="m-gen-art-1"></div>
         <div class="gen-art-mobile" id="m-gen-art-2"></div>

--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -241,8 +241,7 @@
  {{- partial "clipboard-copy.html" . -}}
 </div>
 
-<!-- partners -->
-
+<!-- partners
 <section class="partners">
   <div class="gen-art" id="gen-art-10"></div>
   <div class="container">
@@ -250,7 +249,6 @@
       <div class="col-xl-6 col-lg-6 col-md-6 col-sm-12" style="position:relative; z-index: 2; margin-top: 20px;">
         <h2>partners</h2>
         <p>At our core, tea is about building an open-source ecosystem that is fair for everyone. This is an enormous undertaking and we can’t do it alone. Here we want to thank those that have already enlisted for the Open-Source Revolution.</p>
-        <!-- Add in community to partners, with large metric feed. Maybe use fists icon for that -->
       </div>
       <div class="col">
 
@@ -265,5 +263,5 @@
     </div>
   </div>
 </section>
-
+-->
 {{ end }}

--- a/src/layouts/page/products.html
+++ b/src/layouts/page/products.html
@@ -120,7 +120,7 @@
 </section>
 
 <hr>
-
+<!--
 <section class="products-tea-package-manager">
   <div class="container product-container">
     <div class="row">
@@ -135,7 +135,7 @@
     </div>
   </div>
 </section>
-
+-->
 {{- partial "full-width-cta.html" -}}
 
 {{ end }}

--- a/src/layouts/page/tea-cli.html
+++ b/src/layouts/page/tea-cli.html
@@ -5,7 +5,7 @@
     <div class="row">
       <div class="col my-auto">
         <h1>TEA CLI</h1>
-        <p class="lead">brew2 for web3 is here. The minds that changed the interwebs for the better back in 2009 have just done it again. tea is here to help make your dev experience a little more delightful. </p>
+        <p class="lead">Access the latest tools, languages and frameworks seamlessly across all platforms with tea&#8212;the standalone, binary download from the creator of <a href="https://brew.sh/">brew</a>.</p>
       </div>
     </div>
   </div>

--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -6,7 +6,7 @@
       <div class="row footer-top one-box-down">
         <div class="col-lg-8 footer-content">
           <h4>Changing the way you build. And what happens after you build it.</h4>
-          <p>tea.cli is a delightful package manager that gets out of your way and sets you up for a joyful development process. <a class="teal" href="#">You can install it today</a>. Our web3 protocol will create an OSS ecosystem that is safer for all users, and fair for all maintainers. Read our <a class="teal" href="#">white paper</a> here.</p>
+          <p>tea.cli is a delightful package manager that gets out of your way and sets you up for a joyful development process. <a class="teal" href="#">You can install it today</a>. <!--Our web3 protocol will create an OSS ecosystem that is safer for all users, and fair for all maintainers. Read our <a class="teal" href="#">white paper</a> here.--></p>
           <img class="footer-grid" src="/Images/footer-grid-element.svg" alt="tea.grid">
           <img class="mobile-grid-element" src="/Images/mobile-grid-element-3-rows.svg" alt="grid">
         </div>

--- a/src/layouts/partials/footer.html
+++ b/src/layouts/partials/footer.html
@@ -101,7 +101,6 @@ integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+
 
   <script>
     const textList = [
-    "web3",
     "game&#8208;dev",
     "AI",
     "automation",


### PR DESCRIPTION
Removed web3 verbiage from index and ancillary pages and replaced with tea-cli/OSS-focused verbiage. This is a short-term fix, as the new landing page/website design will have a more concise, singular focus on the product as well as on the open-source community.