### PR TITLE
Add text about additional install methods below one-liner

### DIFF
--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -160,12 +160,21 @@
     <div class="row">
       <div class="col">
         {{- partial "click-to-copy.html" . -}}
+        <p class="no-installer grid-gray text-center"><span class="tea">tea</span> is a stand&#8208;alone binary, see <a class="install-link" href="https://docs.tea.xyz/getting-started/install-tea/without-installer">our docs</a> for more installation methods.</p>
       </div>
     </div>
   </div>
 </section>
 
 <style>
+
+    .install-link{
+      color: #00ffd0;
+    }
+
+    .install-link:hover{
+      color: #ffffff;
+    }
 
     .term-icon{
       position: relative;


### PR DESCRIPTION
Added sentence about additional install methods below one-liner:

<img width="1145" alt="Screen Shot 2023-03-20 at 11 08 20 AM" src="https://user-images.githubusercontent.com/49042513/226385102-57599d75-b636-468f-be62-1a3729dc057a.png">


Links to:

https://docs.tea.xyz/getting-started/install-tea/without-installer