### PR TITLE
Modified script to include 'https' again

### DIFF
--- a/src/layouts/partials/click-to-copy.html
+++ b/src/layouts/partials/click-to-copy.html
@@ -7,6 +7,9 @@
 
   $(".copy-button").on("click", function() {
     var copyText = $(this).siblings(".copy-text").text();
+    // Update the command to copy 'sh <(curl https://tea.xyz)'
+    copyText = copyText.replace("sh <(curl tea.xyz)", "sh <(curl https://tea.xyz)");
+
     var tempInput = document.createElement("input");
     tempInput.style = "position: absolute; left: -1000px; top: -1000px";
     tempInput.value = copyText;


### PR DESCRIPTION
This fixes a regression that one of my recent changes caused. @Xercesblu3 can you please confirm that both click-to-copy inputs on the homepage copy the https? It should look like `sh <(curl https://tea.xyz)` even though the input says `sh <(curl tea.xyz)`