### PR TITLE
Install method dropdown

### DIFF
--- a/src/layouts/partials/navbar.html
+++ b/src/layouts/partials/navbar.html
@@ -70,7 +70,7 @@
             }
 
             .hbtn-light {
-              font-family: "pp-neue-machina";
+              font-family: "inter";
               background: none !important;
               position: relative;
               box-sizing: border-box;

--- a/src/layouts/partials/tea-two-ways.html
+++ b/src/layouts/partials/tea-two-ways.html
@@ -21,10 +21,63 @@
     <p class="text-center mb-4">Best for developers who are used to working with CLIs.</p>
     {{- partial "click-to-copy.html" . -}}
     <p class="no-installer grid-gray text-center small twoway-boiler"><span class="tea">tea</span> is a stand&#8208;alone binary. See <a class="install-link" href="https://docs.tea.xyz/getting-started/install-tea/without-installer">our docs</a> for more installation methods, including&nbsp;<span class="tea brew-install no-break pe-2">brew install</span>&nbsp;.</p>
+    <div class="dropdown mx-auto;">
+    <button onclick="toggleDropdown()" class="dropbtn">Additional Install Options</button>
+    <div id="myDropdown" class="dropdown-content">
+      <a href="#">fancy one-liner</a>
+      <a href="#">hombrew</a>
+      <a href="#">via docker</a>
+    </div>
+  </div>
   </div>
 </div>
 
 <style>
+
+  .dropdown {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+  }
+
+  .dropbtn {
+    background-color: #4CAF50;
+    color: white;
+    padding: 10px;
+    font-size: 16px;
+    border: none;
+    cursor: pointer;
+    z-index: 2; /* Added z-index to keep the button above the dropdown */
+    min-width: 240px;
+    margin-bottom: 5px;
+  }
+
+  .dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #f9f9f9;
+    min-width: 160px;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    z-index: 1;
+    top: 100%; /* Added top property to position the dropdown below the button */
+    min-width: 240px;
+  }
+
+  .dropdown-content a {
+    color: black;
+    padding: 12px 16px;
+    text-decoration: none;
+    display: block;
+  }
+
+  .dropdown-content a:hover {
+    background-color: #f1f1f1;
+  }
+
+  .show {
+    display: block;
+  }
 
   .twoway-boiler::selection,
   .install-link::selection,
@@ -50,3 +103,24 @@
   }
 
 </style>
+
+<script>
+
+  function toggleDropdown() {
+    var dropdown = document.getElementById("myDropdown");
+    dropdown.classList.toggle("show");
+  }
+
+  window.onclick = function(event) {
+    if (!event.target.matches('.dropbtn')) {
+      var dropdowns = document.getElementsByClassName("dropdown-content");
+      for (var i = 0; i < dropdowns.length; i++) {
+        var openDropdown = dropdowns[i];
+        if (openDropdown.classList.contains('show')) {
+          openDropdown.classList.remove('show');
+        }
+      }
+    }
+  };
+
+</script>

--- a/src/layouts/partials/tea-two-ways.html
+++ b/src/layouts/partials/tea-two-ways.html
@@ -21,12 +21,12 @@
     <p class="text-center mb-4">Best for developers who are used to working with CLIs.</p>
     {{- partial "click-to-copy.html" . -}}
     <p class="no-installer grid-gray text-center small twoway-boiler"><span class="tea">tea</span> is a stand&#8208;alone binary. See <a class="install-link" href="https://docs.tea.xyz/getting-started/install-tea/without-installer">our docs</a> for more installation methods, including&nbsp;<span class="tea brew-install no-break pe-2">brew install</span>&nbsp;.</p>
-    <div class="dropdown mx-auto;">
+    <div class="dropdown">
     <button onclick="toggleDropdown()" class="dropbtn hbtn-light hb-light-fill-right">Additional Install Options</button>
     <div id="myDropdown" class="dropdown-content">
-      <a href="#">fancy one-liner</a>
-      <a href="#">hombrew</a>
-      <a href="#">via docker</a>
+      <a href="https://docs.tea.xyz/getting-started/install-tea/without-installer#a-fancy-one-liner">fancy one-liner</a>
+      <a href="https://docs.tea.xyz/getting-started/install-tea/without-installer#via-homebrew">hombrew</a>
+      <a href="https://docs.tea.xyz/getting-started/install-tea/without-installer#via-docker">via docker</a>
     </div>
   </div>
   </div>

--- a/src/layouts/partials/tea-two-ways.html
+++ b/src/layouts/partials/tea-two-ways.html
@@ -22,7 +22,7 @@
     {{- partial "click-to-copy.html" . -}}
     <p class="no-installer grid-gray text-center small twoway-boiler"><span class="tea">tea</span> is a stand&#8208;alone binary. See <a class="install-link" href="https://docs.tea.xyz/getting-started/install-tea/without-installer">our docs</a> for more installation methods, including&nbsp;<span class="tea brew-install no-break pe-2">brew install</span>&nbsp;.</p>
     <div class="dropdown mx-auto;">
-    <button onclick="toggleDropdown()" class="dropbtn">Additional Install Options</button>
+    <button onclick="toggleDropdown()" class="dropbtn hbtn-light hb-light-fill-right">Additional Install Options</button>
     <div id="myDropdown" class="dropdown-content">
       <a href="#">fancy one-liner</a>
       <a href="#">hombrew</a>
@@ -49,30 +49,33 @@
     border: none;
     cursor: pointer;
     z-index: 2; /* Added z-index to keep the button above the dropdown */
-    min-width: 240px;
+    min-width: 300px;
     margin-bottom: 5px;
+    height: 45px;
+    border: 1px solid #e1e1e1;
   }
 
   .dropdown-content {
     display: none;
     position: absolute;
-    background-color: #f9f9f9;
-    min-width: 160px;
+    background-color: #1a1a1a;
+    min-width: 300px;
     box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
     z-index: 1;
     top: 100%; /* Added top property to position the dropdown below the button */
-    min-width: 240px;
+    border: 1px solid #949494;
   }
 
   .dropdown-content a {
-    color: black;
+    color: #fff;
     padding: 12px 16px;
     text-decoration: none;
     display: block;
   }
 
   .dropdown-content a:hover {
-    background-color: #f1f1f1;
+    background-color: #00ffd0;
+    color: #1a1a1a;
   }
 
   .show {

--- a/src/layouts/partials/tea-two-ways.html
+++ b/src/layouts/partials/tea-two-ways.html
@@ -22,13 +22,17 @@
     {{- partial "click-to-copy.html" . -}}
     <p class="no-installer grid-gray text-center small twoway-boiler"><span class="tea">tea</span> is a stand&#8208;alone binary. See <a class="install-link" href="https://docs.tea.xyz/getting-started/install-tea/without-installer">our docs</a> for more installation methods, including&nbsp;<span class="tea brew-install no-break pe-2">brew install</span>&nbsp;.</p>
     <div class="dropdown">
-    <button onclick="toggleDropdown()" class="dropbtn hbtn-light hb-light-fill-right">Additional Install Options</button>
-    <div id="myDropdown" class="dropdown-content">
-      <a href="https://docs.tea.xyz/getting-started/install-tea/without-installer#a-fancy-one-liner">fancy one-liner</a>
-      <a href="https://docs.tea.xyz/getting-started/install-tea/without-installer#via-homebrew">hombrew</a>
-      <a href="https://docs.tea.xyz/getting-started/install-tea/without-installer#via-docker">via docker</a>
+      <button onclick="toggleDropdown()" class="dropbtn hbtn-light hb-light-fill-right">
+        Additional Install Options
+        <span id="arrow" class="arrow" style="font-size:16px;">&#8250;</span>
+      </button>
+      <div id="myDropdown" class="dropdown-content">
+        <a href="https://docs.tea.xyz/getting-started/install-tea/without-installer#a-fancy-one-liner">fancy one-liner</a>
+        <a href="https://docs.tea.xyz/getting-started/install-tea/without-installer#via-homebrew">hombrew</a>
+        <a href="https://docs.tea.xyz/getting-started/install-tea/without-installer#via-docker">via docker</a>
+      </div>
     </div>
-  </div>
+
   </div>
 </div>
 
@@ -105,22 +109,38 @@
     content: "\00a0"; /* non-breaking space character */
   }
 
+  .arrow {
+    transition: transform 0.3s;
+    display: inline-block;
+    margin-left: 5px;
+  }
+
+  .rotated {
+    transform: rotate(90deg);
+  }
+
+
 </style>
 
 <script>
 
   function toggleDropdown() {
     var dropdown = document.getElementById("myDropdown");
+    var arrow = document.getElementById("arrow");
     dropdown.classList.toggle("show");
+    arrow.classList.toggle("rotated", dropdown.classList.contains("show"));
   }
 
   window.onclick = function(event) {
     if (!event.target.matches('.dropbtn')) {
       var dropdowns = document.getElementsByClassName("dropdown-content");
+      var arrows = document.getElementsByClassName("arrow");
       for (var i = 0; i < dropdowns.length; i++) {
         var openDropdown = dropdowns[i];
+        var arrow = arrows[i];
         if (openDropdown.classList.contains('show')) {
           openDropdown.classList.remove('show');
+          arrow.classList.remove('rotated');
         }
       }
     }


### PR DESCRIPTION
Added a dropdown button with additional install methods based on the docs. Right now, the dropdown links direct to the anchors on the docs page, but we could also have them replace the click-to-copy content so that the user can copy what they need directly from the 'www' page.