### PR TITLE
contributors-list: update repos

### DIFF
--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -1016,7 +1016,7 @@ A GUI & CLI for complex apps, incentives on chain, & much more.</p>
 
   var contributorsList = $("#contributors-list");
 
-  var repos = ["cli", "pantry.extra", "pantry.zero", "white-paper", "setup", "brewkit", "www", "kettle", "demos"];
+  var repos = ["cli", "pantry.extra", "pantry.core", "white-paper", "setup", "brewkit", "www", "gui", "demos"];
 
   var uniqueContributors = {};
 


### PR DESCRIPTION
as teaxyz/www#290 didn't add gui repo (was private) and now it is public.

also requesting Github API on `pantry.zero` (replaced by `pantry.core`) and `kettle` returns 404.