### PR TITLE
gui cta icon amendment

### DIFF
--- a/src/layouts/page/gui.html
+++ b/src/layouts/page/gui.html
@@ -12,12 +12,12 @@
           <div style="display:flex;align-items:flex-start;">
             <div class="">
               <a href="https://dist.tea.xyz/tea.xyz/gui/tea-latest-arm64.dmg">
-                <button class="hbtn hb-fill-right gui-dl-click" style="width:180px;height:40px;font-size:14px;"><i class="icon-apple"></i>M1/M2 Chip</button>
+                <button class="hbtn hb-fill-right gui-dl-click" style="width:180px;height:40px;font-size:14px;">M1/M2 Chip</button>
               </a>
             </div>
             <div class="ms-3">
               <a href="https://dist.tea.xyz/tea.xyz/gui/tea-latest.dmg">
-                <button class="hbtn hb-fill-right gui-dl-click" style="width:180px;height:40px;font-size:14px;"><i class="icon-apple"></i>Intel Chip</button>
+                <button class="hbtn hb-fill-right gui-dl-click" style="width:180px;height:40px;font-size:14px; padding:0px;">Intel Chip</button>
               </a>
             </div>
           </div>


### PR DESCRIPTION
As `iamman` pointed out on Discord, the Intel CTA on the /gui page has an Apple icon and an Intel icon would be more appropriate. However, as Intel does not have an icon, the full logo used as an icon looked a little cluttered (as well as redundant). Thus, the icons on both buttons have been removed.